### PR TITLE
return HTTP status 404 in case of internal server error so that Go cl…

### DIFF
--- a/go/internal/pkg/server/gomodule/gomodule.go
+++ b/go/internal/pkg/server/gomodule/gomodule.go
@@ -98,18 +98,18 @@ func (s *Server) authorize(identity *auth.Identity, modulePath string) config.Ac
 func (s *Server) latest(rw http.ResponseWriter, req *http.Request, modulePath string) {
 	info, err := s.goModuleService.Latest(req.Context(), modulePath)
 	if err != nil {
-		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) {
+		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) || servicegomodule.ErrorIsCode(err, servicegomodule.ParentProxyGoogleVPCError) {
 			http.Error(rw, fmt.Sprintf("not found: %v", err), http.StatusNotFound)
 			return
 		}
 		log.Errorf("error getting info for latest version of module %s: %v", modulePath, err)
-		http.Error(rw, fmt.Sprintf("error while getting info for latest version of module %s", modulePath), http.StatusInternalServerError)
+		http.Error(rw, fmt.Sprintf("not found: error while getting info for latest version of module %s", modulePath), http.StatusNotFound)
 		return
 	}
 	infoJSONBytes, err := json.Marshal(info)
 	if err != nil {
 		log.Errorf("error marshalling info of latest version of module %s: %v", modulePath, err)
-		http.Error(rw, fmt.Sprintf("error marshalling info of latest version of module %s", modulePath), http.StatusInternalServerError)
+		http.Error(rw, fmt.Sprintf("error marshalling info of latest version of module %s", modulePath), http.StatusNotFound)
 		return
 	}
 	rw.Header().Set(headerNameContentType, contentTypeInfo)
@@ -120,12 +120,12 @@ func (s *Server) latest(rw http.ResponseWriter, req *http.Request, modulePath st
 func (s *Server) list(rw http.ResponseWriter, req *http.Request, modulePath string) {
 	d, err := s.goModuleService.List(req.Context(), modulePath)
 	if err != nil {
-		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) {
+		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) || servicegomodule.ErrorIsCode(err, servicegomodule.ParentProxyGoogleVPCError) {
 			http.Error(rw, fmt.Sprintf("not found: %v", err), http.StatusNotFound)
 			return
 		}
 		log.Errorf("error listing versions of module %s: %v", modulePath, err)
-		http.Error(rw, fmt.Sprintf("error listing versions of module %s", modulePath), http.StatusInternalServerError)
+		http.Error(rw, fmt.Sprintf("error listing versions of module %s", modulePath), http.StatusNotFound)
 		return
 	}
 	defer func() {
@@ -147,18 +147,18 @@ func (s *Server) info(rw http.ResponseWriter, req *http.Request, modulePath, ver
 	moduleVersion := module.Version{Path: modulePath, Version: version}
 	info, err := s.goModuleService.Info(req.Context(), &moduleVersion)
 	if err != nil {
-		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) {
+		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) || servicegomodule.ErrorIsCode(err, servicegomodule.ParentProxyGoogleVPCError) {
 			http.Error(rw, fmt.Sprintf("not found: %v", err), http.StatusNotFound)
 			return
 		}
 		log.Errorf("error getting info for module %s: %v", moduleVersion.String(), err)
-		http.Error(rw, fmt.Sprintf("error while getting info for module %s", moduleVersion.String()), http.StatusInternalServerError)
+		http.Error(rw, fmt.Sprintf("error while getting info for module %s", moduleVersion.String()), http.StatusNotFound)
 		return
 	}
 	infoJSONBytes, err := json.Marshal(info)
 	if err != nil {
 		log.Errorf("error marshalling info of latest version of module %s: %v", modulePath, err)
-		http.Error(rw, fmt.Sprintf("error marshalling info of latest version of module %s", modulePath), http.StatusInternalServerError)
+		http.Error(rw, fmt.Sprintf("error marshalling info of latest version of module %s", modulePath), http.StatusNotFound)
 		return
 	}
 	rw.Header().Set(headerNameContentType, contentTypeInfo)
@@ -174,12 +174,12 @@ func (s *Server) goMod(rw http.ResponseWriter, req *http.Request, modulePath, ve
 	moduleVersion := module.Version{Path: modulePath, Version: version}
 	d, err := s.goModuleService.GoMod(req.Context(), &moduleVersion)
 	if err != nil {
-		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) {
+		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) || servicegomodule.ErrorIsCode(err, servicegomodule.ParentProxyGoogleVPCError) {
 			http.Error(rw, fmt.Sprintf("not found: %v", err), http.StatusNotFound)
 			return
 		}
 		log.Errorf("error getting mod file for module %s: %v", moduleVersion.String(), err)
-		http.Error(rw, fmt.Sprintf("error while getting mod file for module %s", moduleVersion.String()), http.StatusInternalServerError)
+		http.Error(rw, fmt.Sprintf("error while getting mod file for module %s", moduleVersion.String()), http.StatusNotFound)
 		return
 	}
 	defer func() {
@@ -269,13 +269,12 @@ func (s *Server) zip(rw http.ResponseWriter, req *http.Request, modulePath, vers
 	moduleVersion := module.Version{Path: modulePath, Version: version}
 	d, err := s.goModuleService.Zip(req.Context(), &moduleVersion)
 	if err != nil {
-		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) {
-			code := http.StatusNotFound
-			http.Error(rw, http.StatusText(code), code)
+		if servicegomodule.ErrorIsCode(err, servicegomodule.NotFound) || servicegomodule.ErrorIsCode(err, servicegomodule.ParentProxyGoogleVPCError) {
+			http.Error(rw, fmt.Sprintf("not found: %v", err), http.StatusNotFound)
 			return
 		}
 		log.Errorf("error getting zip file for module %s: %v", moduleVersion.String(), err)
-		http.Error(rw, fmt.Sprintf("error getting zip file for module %s", moduleVersion.String()), http.StatusInternalServerError)
+		http.Error(rw, fmt.Sprintf("error getting zip file for module %s", moduleVersion.String()), http.StatusNotFound)
 		return
 	}
 	defer func() {

--- a/go/internal/pkg/service/gomodule/error.go
+++ b/go/internal/pkg/service/gomodule/error.go
@@ -9,6 +9,13 @@ type ErrorCode int
 
 const (
 	NotFound ErrorCode = iota
+
+	// ParentProxyGoogleVPCError indicates an error occured downloading a module from the parent proxy and the error is known to indicate
+	// that the parent proxy returned a HTTP 302 redirect response to a signed URL of a Google Cloud Storage (GCS) object, but the Google Cloud
+	// Storage object could not be downloaded because Google Virtual Private Cloud (VPC) Service Controls blocked it.
+	// This error code exists to work around a misconfiguration in parent proxies that are in the same VPC as this module proxy, but do
+	// not proxy GCS reqquests to outside the VPC.
+	ParentProxyGoogleVPCError
 )
 
 func ErrorIsCode(err error, code ErrorCode) bool {

--- a/go/internal/pkg/service/gomodule/gocmd/service.go
+++ b/go/internal/pkg/service/gomodule/gocmd/service.go
@@ -192,6 +192,10 @@ func (s *Service) getGoModuleAndIndexIfNeeded(ctx context.Context, tempGoEnv *te
 		return
 	}
 	if downloadInfo.Error != nil {
+		if looksLikeGoogleVirtualPrivateCloudError(downloadInfo.Error.Err) {
+			err = gomoduleservice.NewErrorf(gomoduleservice.ParentProxyGoogleVPCError, "parent proxy Google Virtual Private Cloud Service Controls error: %s", downloadInfo.Error)
+			return
+		}
 		err = fmt.Errorf("command %s succeeded but got unexpected error loading module:\n%s", formatArgs(args), strLog)
 		return
 	}

--- a/go/internal/pkg/service/gomodule/gocmd/util.go
+++ b/go/internal/pkg/service/gomodule/gocmd/util.go
@@ -3,6 +3,7 @@ package gocmd
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -29,4 +30,49 @@ func fdSeekToStart(fd *os.File) error {
 		return fmt.Errorf("(*os.File).Seek(0, io.SeekStart) returned unexpected non-zero offset %d", offset)
 	}
 	return nil
+}
+
+// looksLikeGoogleVirtualPrivateCloudError is tests if errorString ends with something like:
+// : reading https://proxy.golang.org/google.golang.org/api/@v/v0.8.0.zip: 403 Forbidden
+func looksLikeGoogleVirtualPrivateCloudError(errorString string) bool {
+	rest := errorString
+	i := strings.LastIndexByte(rest, ':')
+	if i < 0 {
+		return false
+	}
+	part := rest[i+1:]
+	part = strings.Trim(part, " ")
+	rest = rest[:i]
+	if !strings.EqualFold(part, "403 Forbidden") {
+		return false
+	}
+	i = strings.LastIndexByte(rest, ':')
+	if i < 0 {
+		return false
+	}
+	j := strings.LastIndexByte(rest[:i], ':')
+	if j < 0 {
+		part = rest
+	} else {
+		part = rest[j+1:]
+	}
+	part = strings.Trim(part, " ")
+	i = strings.IndexByte(part, ' ')
+	if i < 0 {
+		return false
+	}
+	partPrefix := part[:i]
+	if !strings.EqualFold(partPrefix, "reading") {
+		return false
+	}
+	partSuffix := strings.TrimLeft(part[i+1:], " ")
+	if partSuffixURL, err := url.Parse(partSuffix); err != nil {
+		return false
+	} else {
+		partSuffixURL.User = nil
+		if strings.HasPrefix(partSuffixURL.String(), "https://proxy.golang.org/google.golang.org/") {
+			return true
+		}
+	}
+	return false
 }

--- a/go/internal/pkg/service/gomodule/gocmd/util_test.go
+++ b/go/internal/pkg/service/gomodule/gocmd/util_test.go
@@ -1,0 +1,14 @@
+package gocmd
+
+import (
+	"testing"
+)
+
+func Test_LooksLikeGoogleVirtualPrivateCloudError_Test(t *testing.T) {
+	errorString := `: reading https://proxy.golang.org/google.golang.org/api/@v/v0.8.0.zip: 403 Forbidden`
+	x := looksLikeGoogleVirtualPrivateCloudError(errorString)
+	if !x {
+		t.Logf("error %#v", errorString)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Changes:
1. return HTTP status 404 in case of internal server error so that Go clients can then fall back by default (improved reliability)
1. improve error message in case of VPC error