### PR TITLE
Optimize latest

### DIFF
--- a/go/internal/pkg/config/httpproxy.go
+++ b/go/internal/pkg/config/httpproxy.go
@@ -136,15 +136,16 @@ func GetHTTPProxyInfoAndUnsetEnviron(cfg *Config) (*HTTPProxyInfo, error) {
 	} else {
 		log.Infof(`effective source of HTTP forward proxy bypass ("NO_PROXY"): %s`, noProxySource)
 	}
-	proxyURLString := proxyURL.String()
-	proxyFunc, err := internalhttpproxy.ProxyFunc(noProxy, proxyURLString)
-	if err != nil {
-		return nil, err
-	}
 	h := &HTTPProxyInfo{
-		ProxyFunc:         proxyFunc,
-		LibcurlNoProxy:    libcurlNoProxy,
-		LibcurlHTTPSProxy: proxyURLString,
+		LibcurlNoProxy: libcurlNoProxy,
+	}
+	if proxyURL != nil {
+		h.LibcurlHTTPSProxy = proxyURL.String()
+		var err error
+		h.ProxyFunc, err = internalhttpproxy.ProxyFunc(noProxy, h.LibcurlHTTPSProxy)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return h, nil
 }

--- a/go/internal/pkg/server/gomodule/gomodule.go
+++ b/go/internal/pkg/server/gomodule/gomodule.go
@@ -60,8 +60,8 @@ func NewServer(opts ServerOptions) (*Server, error) {
 	if opts.GoModuleService == nil {
 		return nil, fmt.Errorf("opts.GoModuleService must not be nil")
 	}
-	if opts.RequestAuthenticator == nil {
-		return nil, fmt.Errorf("opts.RequestAuthenticator must not be nil")
+	if opts.ClientAuthEnabled && opts.RequestAuthenticator == nil {
+		return nil, fmt.Errorf("if opts.ClientAuthEnabled is true then opts.RequestAuthenticator must not be nil")
 	}
 	s := &Server{
 		acl:                  opts.AccessControlList,

--- a/go/internal/pkg/service/gomodule/gocmd/http.go
+++ b/go/internal/pkg/service/gomodule/gocmd/http.go
@@ -1,0 +1,44 @@
+package gocmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	module "golang.org/x/mod/module"
+
+	gomoduleservice "github.com/go-mod-proxy/go/internal/pkg/service/gomodule"
+	"github.com/go-mod-proxy/go/internal/pkg/util"
+)
+
+var errHTTPNotFound = errors.New("not found")
+
+func httpLatest(ctx context.Context, baseURL string, client *http.Client, modulePath string) (*gomoduleservice.Info, error) {
+	modulePathEscaped, err := module.EscapePath(modulePath)
+	if err != nil {
+		return nil, fmt.Errorf("modulePath is invalid: %v", err)
+	}
+	url := baseURL + modulePathEscaped + "/@latest"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+			return nil, errHTTPNotFound
+		}
+		return nil, fmt.Errorf("server gave unexpected %d-response to %s %s", resp.StatusCode, req.Method, url)
+	}
+	x := &gomoduleservice.Info{}
+	if err := util.UnmarshalJSON(resp.Body, x, false); err != nil {
+		return nil, fmt.Errorf("error unmarshalling body of %d-response to %s %s: %v", resp.StatusCode,
+			req.Method, url, err)
+	}
+	return x, nil
+}

--- a/go/internal/pkg/service/gomodule/gocmd/service.go
+++ b/go/internal/pkg/service/gomodule/gocmd/service.go
@@ -425,16 +425,18 @@ func (s *Service) infoFromConcatObj(ctx context.Context, moduleVersion *module.V
 				}
 			}
 		}()
-		commitTime, _, _, _, err := parseConcatObjCommon(data)
+		var commitTime time.Time
+		commitTime, _, _, _, err = parseConcatObjCommon(data)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing concat obj's data: %w", err)
+			err = fmt.Errorf("error parsing concat obj's data: %w", err)
+			return
 		}
-		return &gomoduleservice.Info{
+		i = &gomoduleservice.Info{
 			Time:    commitTime,
 			Version: moduleVersion.Version,
-		}, nil
+		}
 	}
-	return nil, err
+	return
 }
 
 func (s *Service) infoFromGoModObj(ctx context.Context, moduleVersion *module.Version) (*gomoduleservice.Info, error) {

--- a/go/internal/pkg/service/storage/gcs/gcs.go
+++ b/go/internal/pkg/service/storage/gcs/gcs.go
@@ -82,7 +82,7 @@ func (s *Storage) CreateObjectExclusively(ctx context.Context,
 	// This can also be implemented using s.gcsClientBucket.Object(name).
 	//		If(gcs.Conditions{DoesNotExist:true}).
 	//		NewWriter(ctx)
-	// but the current implementation does a single multipart/related HTTP request rather
+	// but this implementation does a single multipart/related HTTP request rather
 	// than 2 or more requests with s.gcsClientBucket approach (assuming non-empty body), and
 	// sets the fields parameter.
 	// A disadvantage is that there's more code in our case.


### PR DESCRIPTION
Changes:
1. Fix hiding of error in function `infoFromConcatObj`
2. Optimise GET ...`/@latest` endpoint for public modules by querying parent proxy directly (this cannot be done for private modules). See comments.
3. Do not require `.clientAuth.authenticators.accessToken` to be set when `.clientAuth.enabled` is not `true`. Fix various other cases where we cannot just set `.clientAuth.enabled` to not be `true`. This fixes https://github.com/go-mod-proxy/go-mod-proxy/issues/8.
4. Do not require `.httpProxy` to be set.

3 and 4 make the server more easy to run locally, as you now "just" need a GCS bucket.