### PR TITLE
optimise list

### DIFF
--- a/go/internal/pkg/modproxyclient/error.go
+++ b/go/internal/pkg/modproxyclient/error.go
@@ -1,0 +1,7 @@
+package modproxyclient
+
+import (
+	"errors"
+)
+
+var ErrNotFound = errors.New("not found")

--- a/go/internal/pkg/modproxyclient/latest.go
+++ b/go/internal/pkg/modproxyclient/latest.go
@@ -1,0 +1,41 @@
+package modproxyclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	module "golang.org/x/mod/module"
+
+	gomoduleservice "github.com/go-mod-proxy/go/internal/pkg/service/gomodule"
+	"github.com/go-mod-proxy/go/internal/pkg/util"
+)
+
+func Latest(ctx context.Context, baseURL string, client *http.Client, modulePath string) (*gomoduleservice.Info, error) {
+	modulePathEscaped, err := module.EscapePath(modulePath)
+	if err != nil {
+		return nil, fmt.Errorf("modulePath is invalid: %v", err)
+	}
+	url := baseURL + modulePathEscaped + "/@latest"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("server gave unexpected %d-response to %s %s", resp.StatusCode, req.Method, url)
+	}
+	x := &gomoduleservice.Info{}
+	if err := util.UnmarshalJSON(resp.Body, x, false); err != nil {
+		return nil, fmt.Errorf("error unmarshalling body of %d-response to %s %s: %v", resp.StatusCode,
+			req.Method, url, err)
+	}
+	return x, nil
+}

--- a/go/internal/pkg/modproxyclient/list.go
+++ b/go/internal/pkg/modproxyclient/list.go
@@ -1,51 +1,16 @@
-package gocmd
+package modproxyclient
 
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 
 	module "golang.org/x/mod/module"
-
-	gomoduleservice "github.com/go-mod-proxy/go/internal/pkg/service/gomodule"
-	"github.com/go-mod-proxy/go/internal/pkg/util"
 )
 
-var errHTTPNotFound = errors.New("not found")
-
-func httpLatest(ctx context.Context, baseURL string, client *http.Client, modulePath string) (*gomoduleservice.Info, error) {
-	modulePathEscaped, err := module.EscapePath(modulePath)
-	if err != nil {
-		return nil, fmt.Errorf("modulePath is invalid: %v", err)
-	}
-	url := baseURL + modulePathEscaped + "/@latest"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
-			return nil, errHTTPNotFound
-		}
-		return nil, fmt.Errorf("server gave unexpected %d-response to %s %s", resp.StatusCode, req.Method, url)
-	}
-	x := &gomoduleservice.Info{}
-	if err := util.UnmarshalJSON(resp.Body, x, false); err != nil {
-		return nil, fmt.Errorf("error unmarshalling body of %d-response to %s %s: %v", resp.StatusCode,
-			req.Method, url, err)
-	}
-	return x, nil
-}
-
-func httpList(ctx context.Context, baseURL string, client *http.Client, modulePath string) ([]string, error) {
+func List(ctx context.Context, baseURL string, client *http.Client, modulePath string) ([]string, error) {
 	modulePathEscaped, err := module.EscapePath(modulePath)
 	if err != nil {
 		return nil, fmt.Errorf("modulePath is invalid: %v", err)
@@ -62,7 +27,7 @@ func httpList(ctx context.Context, baseURL string, client *http.Client, modulePa
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
-			return nil, errHTTPNotFound
+			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("server gave unexpected %d-response to %s %s", resp.StatusCode, req.Method, url)
 	}

--- a/go/internal/pkg/service/gomodule/gocmd/http.go
+++ b/go/internal/pkg/service/gomodule/gocmd/http.go
@@ -1,9 +1,11 @@
 package gocmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	module "golang.org/x/mod/module"
@@ -41,4 +43,47 @@ func httpLatest(ctx context.Context, baseURL string, client *http.Client, module
 			req.Method, url, err)
 	}
 	return x, nil
+}
+
+func httpList(ctx context.Context, baseURL string, client *http.Client, modulePath string) ([]string, error) {
+	modulePathEscaped, err := module.EscapePath(modulePath)
+	if err != nil {
+		return nil, fmt.Errorf("modulePath is invalid: %v", err)
+	}
+	url := baseURL + modulePathEscaped + "/@v/list"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+			return nil, errHTTPNotFound
+		}
+		return nil, fmt.Errorf("server gave unexpected %d-response to %s %s", resp.StatusCode, req.Method, url)
+	}
+	bytesRemainding, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading body of %d-response to %s %s: %v", resp.StatusCode,
+			req.Method, url, err)
+	}
+	var versions []string
+	for len(bytesRemainding) > 0 {
+		i := bytes.IndexByte(bytesRemainding, '\n')
+		if i < 0 {
+			return nil, fmt.Errorf("body of response to %s %s unexpectedly is not empty and does not end with a line-feed",
+				req.Method, url)
+		}
+		version := string(bytesRemainding[:i])
+		if version == "" {
+			return nil, fmt.Errorf("body of response to %s %s unexpectedly contains an empty line", req.Method, url)
+		}
+		versions = append(versions, version)
+		bytesRemainding = bytesRemainding[i+1:]
+	}
+	return versions, nil
 }

--- a/go/internal/pkg/service/gomodule/gocmd/service.go
+++ b/go/internal/pkg/service/gomodule/gocmd/service.go
@@ -695,9 +695,6 @@ func (s *Service) List(ctx context.Context, modulePath string) (io.ReadCloser, e
 	}
 	var waitGroup sync.WaitGroup
 	for _, version := range goListVersions {
-		if module.IsPseudoVersion(version) {
-			continue
-		}
 		versionMapMutex.Lock()
 		_, flag := versionMap[version]
 		versionMapMutex.Unlock()
@@ -808,15 +805,7 @@ func (s *Service) listGoCmd(ctx context.Context, modulePath string) (goListVersi
 		err = fmt.Errorf("command %s succeeded but got unexpected stderr/stdout:\n%s", formatArgs(args), strLog)
 		return
 	}
-	if len(goListInfo.Versions) == 0 {
-		if goListInfo.Version == "" {
-			err = fmt.Errorf("command %s succeeded but got unexpected stderr/stdout:\n%s", formatArgs(args), strLog)
-			return
-		}
-		goListVersions = []string{goListInfo.Version}
-	} else {
-		goListVersions = goListInfo.Versions
-	}
+	goListVersions = goListInfo.Versions
 	return
 }
 

--- a/go/internal/pkg/service/gomodule/gocmd/service.go
+++ b/go/internal/pkg/service/gomodule/gocmd/service.go
@@ -653,29 +653,126 @@ func (s *Service) Latest(ctx context.Context, modulePath string) (info *gomodule
 	return
 }
 
-func (s *Service) List(ctx context.Context, modulePath string) (d io.ReadCloser, err error) {
-	err = s.notFoundOptimizations(modulePath)
-	if err != nil {
-		return
+func (s *Service) List(ctx context.Context, modulePath string) (io.ReadCloser, error) {
+	if err := s.notFoundOptimizations(modulePath); err != nil {
+		return nil, err
 	}
 	versionMap := map[string]struct{}{}
-	err = s.listAddObjectNames(ctx, storageGoModObjNamePrefix+modulePath+"@", versionMap)
-	if err != nil {
-		return
-	}
-	err = s.listAddObjectNames(ctx, storageConcatObjNamePrefix+modulePath+"@", versionMap)
-	if err != nil {
-		return
-	}
-	logger := log.StandardLogger()
-	if logLevel := log.TraceLevel; logger.IsLevelEnabled(logLevel) {
-		var sb strings.Builder
-		fmt.Fprintf(&sb, "list for module path %#v initialized with GCS versions: ", modulePath)
-		for version := range versionMap {
-			fmt.Fprintf(&sb, "%#v, ", version)
+	versionMapMutex := new(sync.Mutex)
+	errChan := make(chan error)
+	ctx, cancelFunc := context.WithCancel(ctx)
+	defer cancelFunc()
+	go s.listAddObjectNames(ctx, errChan, storageGoModObjNamePrefix+modulePath+"@", versionMap, versionMapMutex)
+	go s.listAddObjectNames(ctx, errChan, storageConcatObjNamePrefix+modulePath+"@", versionMap, versionMapMutex)
+	var goListVersions []string
+	go func() {
+		var err error
+		goListVersions, err = s.listGoCmd(ctx, modulePath)
+		errChan <- err
+	}()
+	var err error
+	// The constant 3 must be aligned with the number of Goroutines above, and each Goroutine must send on errChan exactly once.
+	for i := 0; i < 3; i++ {
+		err2 := <-errChan
+		if err2 != nil {
+			if err == nil {
+				err = err2
+				cancelFunc()
+			} else {
+				select {
+				case <-ctx.Done():
+					if err == ctx.Err() {
+						continue
+					}
+				default:
+				}
+				log.Errorf("got secondary error while listing versions: %v", err)
+			}
 		}
-		log.NewEntry(logger).Logf(logLevel, sb.String())
 	}
+	if err != nil {
+		return nil, err
+	}
+	var waitGroup sync.WaitGroup
+	for _, version := range goListVersions {
+		if module.IsPseudoVersion(version) {
+			continue
+		}
+		versionMapMutex.Lock()
+		_, flag := versionMap[version]
+		versionMapMutex.Unlock()
+		if flag {
+			continue
+		}
+		version := version
+		runCmdResource, err := s.runCmdResourcePool.acquire(ctx)
+		if err != nil {
+			return nil, err
+		}
+		waitGroup.Add(1)
+		go func() {
+			defer runCmdResource.release()
+			defer waitGroup.Done()
+			tempGoEnv, err := s.newTempGoEnv()
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			defer func() {
+				err := tempGoEnv.removeRef()
+				if err != nil {
+					log.Errorf("error removing tmpDir %#v of *tempGoEnv: %v", tempGoEnv.TmpDir, err)
+				}
+			}()
+			_, _, _, err = s.getGoModuleAndIndexIfNeeded(ctx, tempGoEnv, &module.Version{Path: modulePath, Version: version}, runCmdResource)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			versionMapMutex.Lock()
+			versionMap[version] = struct{}{}
+			versionMapMutex.Unlock()
+		}()
+	}
+	waitGroup.Wait()
+	var sb strings.Builder
+	for version := range versionMap {
+		sb.WriteString(version)
+		sb.WriteByte('\n')
+	}
+	return ioutil.NopCloser(strings.NewReader(sb.String())), nil
+}
+
+func (s *Service) listAddObjectNames(ctx context.Context, errChan chan<- error, namePrefix string,
+	versionMap map[string]struct{}, versionMapMutex *sync.Mutex) {
+	var pageToken string
+	for {
+		var objList *storage.ObjectList
+		objList, err := s.storage.ListObjects(ctx, storage.ObjectListOptions{
+			NamePrefix: namePrefix,
+			PageToken:  pageToken,
+		})
+		if err != nil {
+			errChan <- mapStorageError(err)
+			return
+		}
+		versionMapMutex.Lock()
+		for _, name := range objList.Names {
+			version := name[len(namePrefix):]
+			if !module.IsPseudoVersion(version) {
+				versionMap[version] = struct{}{}
+			}
+		}
+		versionMapMutex.Unlock()
+		pageToken = objList.NextPageToken
+		if pageToken == "" {
+			break
+		}
+	}
+	errChan <- nil
+}
+
+func (s *Service) listGoCmd(ctx context.Context, modulePath string) (goListVersions []string, err error) {
 	tempGoEnv, err := s.newTempGoEnv()
 	if err != nil {
 		return
@@ -711,7 +808,6 @@ func (s *Service) List(ctx context.Context, modulePath string) (d io.ReadCloser,
 		err = fmt.Errorf("command %s succeeded but got unexpected stderr/stdout:\n%s", formatArgs(args), strLog)
 		return
 	}
-	var goListVersions []string
 	if len(goListInfo.Versions) == 0 {
 		if goListInfo.Version == "" {
 			err = fmt.Errorf("command %s succeeded but got unexpected stderr/stdout:\n%s", formatArgs(args), strLog)
@@ -720,82 +816,6 @@ func (s *Service) List(ctx context.Context, modulePath string) (d io.ReadCloser,
 		goListVersions = []string{goListInfo.Version}
 	} else {
 		goListVersions = goListInfo.Versions
-	}
-	var waitGroup sync.WaitGroup
-	var versionMapMutex sync.Mutex
-	for _, version := range goListVersions {
-		if module.IsPseudoVersion(version) {
-			continue
-		}
-		versionMapMutex.Lock()
-		_, flag := versionMap[version]
-		versionMapMutex.Unlock()
-		if flag {
-			continue
-		}
-		version := version
-		var runCmdResource maxParallelismResource
-		runCmdResource, err = s.runCmdResourcePool.acquire(ctx)
-		if err != nil {
-			return
-		}
-		waitGroup.Add(1)
-		go func() {
-			defer runCmdResource.release()
-			defer waitGroup.Done()
-			tempGoEnv, err := s.newTempGoEnv()
-			if err != nil {
-				log.Error(err)
-				return
-			}
-			defer func() {
-				err := tempGoEnv.removeRef()
-				if err != nil {
-					log.Errorf("error removing tmpDir %#v of *tempGoEnv: %v", tempGoEnv.TmpDir, err)
-				}
-			}()
-			_, _, _, err = s.getGoModuleAndIndexIfNeeded(ctx, tempGoEnv, &module.Version{Path: modulePath, Version: version}, runCmdResource)
-			if err != nil {
-				log.Error(err)
-				return
-			}
-			versionMapMutex.Lock()
-			versionMap[version] = struct{}{}
-			versionMapMutex.Unlock()
-		}()
-	}
-	waitGroup.Wait()
-	var sb strings.Builder
-	for version := range versionMap {
-		sb.WriteString(version)
-		sb.WriteByte('\n')
-	}
-	d = ioutil.NopCloser(strings.NewReader(sb.String()))
-	return
-}
-
-func (s *Service) listAddObjectNames(ctx context.Context, namePrefix string, versionMap map[string]struct{}) (err error) {
-	var pageToken string
-	for {
-		var objList *storage.ObjectList
-		objList, err = s.storage.ListObjects(ctx, storage.ObjectListOptions{
-			NamePrefix: namePrefix,
-			PageToken:  pageToken,
-		})
-		if err != nil {
-			err = mapStorageError(err)
-			return
-		}
-		for _, name := range objList.Names {
-			version := name[len(namePrefix):]
-			if !module.IsPseudoVersion(version) {
-				versionMap[version] = struct{}{}
-			}
-		}
-		pageToken = objList.NextPageToken
-		if pageToken == "" {
-			break
-		}
 	}
 	return
 }


### PR DESCRIPTION
Changes:
1. Update list to get versions in parallel
2. Simplify code using the seemingly-fact that go list command does not return pseudo-versions
3. Optimise list for public modules by going to parent proxy directly