### PR TITLE
make strong read-after-list consistency optional

### DIFF
--- a/go/cmd/server/server.go
+++ b/go/cmd/server/server.go
@@ -39,10 +39,11 @@ const maxHeaderBytes = 5 * (1 << 10) // 5 Kibibytes (KiB)
 // CLI is a type reflected by "github.com/alecthomas/kong" that configures the CLI command for the client forward proxy.
 //nolint:structtag // linter does not like the syntax required by the kong package
 type CLI struct {
-	ConfigFile           string `required type:"existingfile" help:"Name of the YAML config file"`
-	Port                 int    `required help:"Port to listen on"`
-	CredentialHelperPort int    `required help:"Credential helper port to listen on"`
-	ScratchDir           string `help:"Directory in which to create temporary scratch files"`
+	ConfigFile                        string `required type:"existingfile" help:"Name of the YAML config file"`
+	ReadAfterListIsStronglyConsistent bool   `help:"Enable strong consistency for read-after-list, and enable strong consistency for read-after-latest for public modules. This decreases performance for list and latest endpoints, but reduces the likelihood of clients seeing errors"`
+	Port                              int    `required help:"Port to listen on"`
+	CredentialHelperPort              int    `required help:"Credential helper port to listen on"`
+	ScratchDir                        string `help:"Directory in which to create temporary scratch files"`
 }
 
 func Run(ctx context.Context, opts *CLI) error {
@@ -248,14 +249,15 @@ func Run(ctx context.Context, opts *CLI) error {
 			shellescape.Quote(executable2),
 			log.GetLevel().String(),
 			opts.CredentialHelperPort),
-		HTTPProxyInfo:       httpProxyInfo,
-		HTTPTransport:       httpTransport,
-		MaxParallelCommands: cfg.MaxChildProcesses,
-		ParentProxy:         cfg.ParentProxy.URLParsed,
-		PrivateModules:      cfg.PrivateModules,
-		PublicModules:       &cfg.PublicModules,
-		ScratchDir:          scratchDir,
-		Storage:             storage,
+		HTTPProxyInfo:                     httpProxyInfo,
+		HTTPTransport:                     httpTransport,
+		MaxParallelCommands:               cfg.MaxChildProcesses,
+		ParentProxy:                       cfg.ParentProxy.URLParsed,
+		PrivateModules:                    cfg.PrivateModules,
+		PublicModules:                     &cfg.PublicModules,
+		ReadAfterListIsStronglyConsistent: opts.ReadAfterListIsStronglyConsistent,
+		ScratchDir:                        scratchDir,
+		Storage:                           storage,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Make strong read-after-list consistency, and strong read-after-latest consistency for public modules, optional and disabled by default. Not needing to guarantee such consistency makes list/latest endpoints faster at the cost of increasing the likelihood of clients seeing errors. This default is better.