### PR TITLE
remove GCS storage bypass opt

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -66,18 +66,6 @@ publicModules:
 
 storage:
   gcs:
-    # When this module proxy server is running on Google Cloud infrastructure and Virtual Private Cloud Service Controls (VPCSC,
-    # https://cloud.google.com/vpc-service-controls) is enabled some HTTP requests to storage.googleapis.com need to go through the HTTP proxy while simultaneously
-    # other HTTP requests to storage.googleapis.com _cannot_ go through the HTTP proxy.
-    # More precisely, a request GET https://proxy.golang.org/google.golang.org/api/@v/v0.3.1.zip to the parent proxy
-    # can return a 302 redirect to a signed GCS object URL (i.e. something of the form
-    #   https://storage.googleapis.com/proxy-golang-org-prod/23434e8d708c9bd3-google.golang.org:api-v0.3.1.zip?Expires=1600814778&GoogleAccessId=gcs-urlsigner-prod%40golang-modproxy.iam.gserviceaccount.com&Signature=...).
-    # When subsequently a GET request of the signed GCS object URL is done, and VPCSC is enabled, the request has
-    # to go via the HTTP proxy, but requests to https://storage.googleapis.com/ as part of this storage backend must not
-    # go via the HTTP proxy.
-    # bypassHTTPProxy should be set to false if and only if this module proxy server is not running in a VPCSC-enabled GCP project and
-    # requests to https://storage.googleapis.com/ done by the storage layer should go via the HTTP proxy.
-    bypassHTTPProxy: true
     bucket: my-gcs-bucket
 
 sumDatabaseProxy:

--- a/config_example_clientauth.yaml
+++ b/config_example_clientauth.yaml
@@ -117,18 +117,6 @@ publicModules:
 
 storage:
   gcs:
-    # When this module proxy server is running on Google Cloud infrastructure and Virtual Private Cloud Service Controls (VPCSC,
-    # https://cloud.google.com/vpc-service-controls) is enabled some HTTP requests to storage.googleapis.com need to go through the HTTP proxy while simultaneously
-    # other HTTP requests to storage.googleapis.com _cannot_ go through the HTTP proxy.
-    # More precisely, a request GET https://proxy.golang.org/google.golang.org/api/@v/v0.3.1.zip to the parent proxy
-    # can return a 302 redirect to a signed GCS object URL (i.e. something of the form
-    #   https://storage.googleapis.com/proxy-golang-org-prod/23434e8d708c9bd3-google.golang.org:api-v0.3.1.zip?Expires=1600814778&GoogleAccessId=gcs-urlsigner-prod%40golang-modproxy.iam.gserviceaccount.com&Signature=...).
-    # When subsequently a GET request of the signed GCS object URL is done, and VPCSC is enabled, the request has
-    # to go via the HTTP proxy, but requests to https://storage.googleapis.com/ as part of this storage backend must not
-    # go via the HTTP proxy.
-    # bypassHTTPProxy should be set to false if and only if this module proxy server is not running in a VPCSC-enabled GCP project and
-    # requests to https://storage.googleapis.com/ done by the storage layer should go via the HTTP proxy.
-    bypassHTTPProxy: true
     bucket: my-gcs-bucket
 
 sumDatabaseProxy:

--- a/go/cmd/server/server.go
+++ b/go/cmd/server/server.go
@@ -96,12 +96,6 @@ func Run(ctx context.Context, opts *CLI) error {
 	httpClient := &http.Client{
 		Transport: httpTransport,
 	}
-	httpTransportBypassProxy := cleanhttp.DefaultPooledTransport()
-	httpTransportBypassProxy.Proxy = nil
-	httpTransportBypassProxy.TLSClientConfig = tlsClientConfig
-	httpClientBypassProxy := &http.Client{
-		Transport: httpTransportBypassProxy,
-	}
 	var enableGCEAuth bool
 	if cfg.ClientAuth.Enabled {
 		for _, identity := range cfg.ClientAuth.Identities {
@@ -113,7 +107,6 @@ func Run(ctx context.Context, opts *CLI) error {
 	}
 	var googleCredentials *google.Credentials
 	var googleHTTPClient *http.Client
-	var googleHTTPClientBypassProxy *http.Client
 	if enableGCEAuth || cfg.Storage.GCS != nil {
 		googleCredentials, err = google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
 		if err != nil {
@@ -125,19 +118,10 @@ func Run(ctx context.Context, opts *CLI) error {
 				Source: googleCredentials.TokenSource,
 			},
 		}
-		googleHTTPClientBypassProxy = &http.Client{
-			Transport: &oauth2.Transport{
-				Base:   httpClientBypassProxy.Transport,
-				Source: googleCredentials.TokenSource,
-			},
-		}
 	}
 	var storage servicestorage.Storage
 	if cfg.Storage.GCS != nil {
 		storageHTTPClient := googleHTTPClient
-		if cfg.Storage.GCS.BypassHTTPProxy {
-			storageHTTPClient = googleHTTPClientBypassProxy
-		}
 		gcsClient, err := gcs.NewClient(ctx, option.WithHTTPClient(storageHTTPClient))
 		if err != nil {
 			return err

--- a/go/internal/pkg/config/configtypes.go
+++ b/go/internal/pkg/config/configtypes.go
@@ -78,8 +78,7 @@ type GCEInstanceIdentityBinding struct {
 }
 
 type GCSStorage struct {
-	BypassHTTPProxy bool   `yaml:"bypassHTTPProxy"`
-	Bucket          string `yaml:"bucket"`
+	Bucket string `yaml:"bucket"`
 }
 
 type GitHubApp struct {


### PR DESCRIPTION
Users should use VPCSC egress policies instead.
See https://github.com/golang/go/issues/49144