### PR TITLE
fix possible error text mangling

### DIFF
--- a/internal/pkg/service/storage/error.go
+++ b/internal/pkg/service/storage/error.go
@@ -41,6 +41,13 @@ type hasCode interface {
 	code() ErrorCode
 }
 
+func NewError(code ErrorCode, s string) error {
+	return &errorStruct{
+		c: code,
+		s: s,
+	}
+}
+
 func NewErrorf(code ErrorCode, format string, args ...interface{}) error {
 	err := fmt.Errorf(format, args...)
 	return &errorStruct{

--- a/internal/pkg/service/storage/error_test.go
+++ b/internal/pkg/service/storage/error_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_NewError(t *testing.T) {
+	err := NewError(NotFound, "object not found")
+	assert.Equal(t, &errorStruct{
+		c: NotFound,
+		s: "object not found",
+	}, err)
+}
+
 func Test_NewErrorf(t *testing.T) {
 	t.Run("C1", func(t *testing.T) {
 		innerError := errors.New("404")

--- a/internal/pkg/service/storage/gcs/gcs.go
+++ b/internal/pkg/service/storage/gcs/gcs.go
@@ -335,12 +335,12 @@ func (s *Storage) ListObjects(ctx context.Context, opts storage.ObjectListOption
 
 func mapGCSPackageError(err error) error {
 	if err == gcs.ErrObjectNotExist {
-		return storage.NewErrorf(storage.NotFound, err.Error(), err)
+		return storage.NewError(storage.NotFound, err.Error())
 	}
 	var googleAPIErr *googleapi.Error
 	if errors.As(err, &googleAPIErr) {
 		if googleAPIErr.Code == http.StatusNotFound {
-			return storage.NewErrorf(storage.NotFound, err.Error(), err)
+			return storage.NewError(storage.NotFound, err.Error())
 		}
 	}
 	return err


### PR DESCRIPTION
Fix issue where the error text for some errors was being printf-interpreted, which can mangle error messages.